### PR TITLE
Problem with lwork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 #
 FC = gfortran
 FFLAGS = -O2 -fopenmp -std=f95 --pedantic -ftrapv
+#FFLAGS= -g -msse4.2  -fcheck=all -Waliasing -Wampersand -Wconversion -Wsurprising -Wintrinsics-std -Wno-tabs -Wintrinsic-shadow -Wline-truncation -Wreal-q-constant -Wuninitialized  -fbacktrace -ffpe-trap=zero,overflow -finit-real=nan
+
 LIBS = -lblas -llapack 
 #LIBS = -L/opt/OpenBLAS/lib -lopenblas
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # diaglib
 
-## Authors and acknowledgment  
-Ivan Gianni', Tommaso Nottoli, Riccardo Alessandro, Federica Pes, and Filippo Lipparini  
-MoLECoLab Pisa  
-Department of Chemistry and Industrial Chemistry  
-University of Pisa  
-Via G. Moruzzi 13, I-56124, Pisa, Italy  
+## Authors and acknowledgment
+Ivan Gianni', Tommaso Nottoli, Riccardo Alessandro, Federica Pes, and Filippo Lipparini
+MoLECoLab Pisa
+Department of Chemistry and Industrial Chemistry
+University of Pisa
+Via G. Moruzzi 13, I-56124, Pisa, Italy
 Pisa, november 2022
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7680658.svg)](https://doi.org/10.5281/zenodo.7680658)
@@ -23,20 +23,20 @@ matrix.
 
 the available algorithms are
 
-1) locally optimal block preconditioned conjugate gradient 
+1) locally optimal block preconditioned conjugate gradient
 
 2) davidson-liu
 
-both algorithms require two user-provided routines to apply the matrx
+both algorithms require two user-provided routines to apply the matrix
 and a suitable preconditioner to a set of vectors.
 such routines have the following interface:
 
-  subroutine matvec(n,m,x,ax)  
+  subroutine matvec(n,m,x,ax)
   subroutine precnd(n,m,shift,x,ax)
 
 where n,m are integers and x(n,m) and ax(n,m) are double precision
 arrays.
-as using the first eigenvalue in a shift-and-invert spirit is very 
+as using the first eigenvalue in a shift-and-invert spirit is very
 common, a double precision scalar shift is also passed to precnd.
 
 both implementations favor numerical stability over efficiency and are

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # diaglib
 
-## Authors and acknowledgment
-Ivan Gianni', Tommaso Nottoli, Riccardo Alessandro, Federica Pes, and Filippo Lipparini
-MoLECoLab Pisa
-Department of Chemistry and Industrial Chemistry
-University of Pisa
-Via G. Moruzzi 13, I-56124, Pisa, Italy
+## Authors and acknowledgment  
+Ivan Gianni', Tommaso Nottoli, Riccardo Alessandro, Federica Pes, and Filippo Lipparini  
+MoLECoLab Pisa  
+Department of Chemistry and Industrial Chemistry  
+University of Pisa  
+Via G. Moruzzi 13, I-56124, Pisa, Italy  
 Pisa, november 2022
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7680658.svg)](https://doi.org/10.5281/zenodo.7680658)
@@ -23,7 +23,7 @@ matrix.
 
 the available algorithms are
 
-1) locally optimal block preconditioned conjugate gradient
+1) locally optimal block preconditioned conjugate gradient 
 
 2) davidson-liu
 
@@ -31,12 +31,12 @@ both algorithms require two user-provided routines to apply the matrix
 and a suitable preconditioner to a set of vectors.
 such routines have the following interface:
 
-  subroutine matvec(n,m,x,ax)
+  subroutine matvec(n,m,x,ax)  
   subroutine precnd(n,m,shift,x,ax)
 
 where n,m are integers and x(n,m) and ax(n,m) are double precision
 arrays.
-as using the first eigenvalue in a shift-and-invert spirit is very
+as using the first eigenvalue in a shift-and-invert spirit is very 
 common, a double precision scalar shift is also passed to precnd.
 
 both implementations favor numerical stability over efficiency and are


### PR DESCRIPTION
Hi, I compiled the library with the following flags:
```
FFLAGS= -g -msse4.2  -fcheck=all -Waliasing -Wampersand -Wconversion -Wsurprising -Wintrinsics-std -Wno-tabs -Wintrinsic-shadow -Wline-truncation -Wreal-q-constant -Wuninitialized  -fbacktrace -ffpe-trap=zero,overflow -finit-real=nan
```

It raised a problem with test number 3 (the SCF-like one):

```
          16     1          4.241558410216  0.2060D-03  0.8798D-03  F
          16     2          5.291463010982  0.2132D-03  0.9276D-03  F
          16     3          6.324572429856  0.4041D-03  0.1580D-02  F
          16     4          7.348486531930  0.2916D-03  0.1140D-02  F
          16     5          8.366612418950  0.7306D-05  0.3634D-04  F
          16     6          9.380840707761  0.1033D-03  0.4719D-03  F
          16     7         10.392313018727  0.2682D-03  0.1451D-02  F
          16     8         11.401762304095  0.3549D-03  0.1849D-02  F
          16     9         12.409683985469  0.4969D-03  0.2615D-02  F
          16    10         13.416412446832  0.2367D-03  0.1238D-02  F
          16    11         14.422210515067  0.3277D-03  0.1718D-02  F
          16    12         15.427251477871  0.1545D-03  0.5687D-03  F
          16    13         16.431678929290  0.1264D-03  0.5877D-03  F
          16    14         17.435597802650  0.1349D-03  0.6536D-03  F
          16    15         18.439096734068  0.4196D-03  0.2110D-02  F
          16    16         19.442242910987  0.7276D-03  0.3397D-02  F
          16    17         20.445061763087  0.5636D-03  0.2274D-02  F
          16    18         21.447699211171  0.1402D-02  0.6817D-02  F
          16    19         22.450159764567  0.2106D-02  0.9588D-02  F
          16    20         23.452339306484  0.2272D-02  0.1051D-01  F

    ----------------------------------------
      # target vectors:      20
      # new vectors added:   25
      # converged vectors:    0
    ----------------------------------------
 lwork        2400

Intel MKL ERROR: Parameter 11 was incorrect on entry to DSYGV .
 info =          -11

Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.

Backtrace for this error:
#0  0x758c3fc23e59 in ???
#1  0x758c3fc22e75 in ???
#2  0x758c3f84532f in ???
	at ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
#3  0x5f80c7fb29e6 in __diaglib_MOD_caslr_driver
	at /home/scemama/Collab/Filippo/diaglib/diaglib.f90:784
#4  0x5f80c7f79c3f in test_scflr_
	at /home/scemama/Collab/Filippo/diaglib/main.f90:843
#5  0x5f80c7f84f65 in MAIN__
	at /home/scemama/Collab/Filippo/diaglib/main.f90:40
#6  0x5f80c7f85057 in main
	at /home/scemama/Collab/Filippo/diaglib/main.f90:2
Floating point exception (core dumped)
```

This is because `lwork` was too small. This PR fixes it! :-)